### PR TITLE
Add \[ \] around styling to avoid breakage.

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -81,10 +81,10 @@ set_prompts() {
         fi;
 
         userhost=""
-        userhost+="\[${userStyle}\]$USER "
-        userhost+="${white}at "
-        userhost+="${orange}$HOSTNAME "
-        userhost+="${white}in"
+        userhost+="\[${userStyle}\]$USER"
+        userhost+="\[${white}\]at "
+        userhost+="\[${orange}\]$HOSTNAME "
+        userhost+="\[${white}\]in"
 
         if [ $USER != "$default_username" ]; then echo $userhost ""; fi
     }


### PR DESCRIPTION
Without the brackets, removing new lines from the prompt breaks the reverse search.